### PR TITLE
Fix for the badge order in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
+# OpenTOSCA UI
 
 [![Build Status](https://travis-ci.org/OpenTOSCA/ui.svg?branch=master)](https://travis-ci.org/OpenTOSCA/ui)
 [![License](https://img.shields.io/badge/License-EPL%201.0-red.svg)](https://opensource.org/licenses/EPL-1.0)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-# OpenTOSCA UI
 
 Part of the [OpenTOSCA Ecosystem](http://www.opentosca.org)
 


### PR DESCRIPTION
#### Short Description
Badges are now directly under the header which is their correct position.
<!-- You can add a screenshot, too -->

<!-- Ensure that the commit message is a good commit message as described at https://github.com/erlang/otp/wiki/Writing-good-commit-messages -->

<!-- List all changes proposed in this pull request -->
