### PR TITLE
Always add trailing slash at winery repository API

### DIFF
--- a/src/app/configuration/configuration.reducer.ts
+++ b/src/app/configuration/configuration.reducer.ts
@@ -38,8 +38,12 @@ export function configurationReducer(state: ConfigurationState = INITIAL_STATE,
                                              action: Action): ConfigurationState {
     switch (action.type) {
         case ConfigurationActions.UPDATE_REPOSITORY_URL:
+            let url = action.payload;
+            if (!url.endsWith('/')) {
+                url = url + '/';
+            }
             return Object.assign({}, state, {
-                repositoryAPI: action.payload
+                repositoryAPI: url
             });
         case ConfigurationActions.UPDATE_CONTAINER_URL:
             return Object.assign({}, state, {


### PR DESCRIPTION
#### Short Description

The code to get something from winery reads

        const url = marketPlaceUrl + encodeURIComponent(encodeURIComponent(appReference.namespace))
            + '/' + encodeURIComponent(encodeURIComponent(appReference.id));    // tslint:disable-line:max-line-length

This leads to strange errors, if http://localhost:8080/winery/servicetemplates is configured as repository URL:

![grafik](https://user-images.githubusercontent.com/18379143/36151694-920d2730-10c8-11e8-89c9-7bf1a6c3729f.png)

#### Proposed Changes

* Silently add trailing slash upon save of repository URL
