### PR TITLE
Add a inputValidation flag to the management-plan-execution-dialog

### DIFF
--- a/src/app/application-management/application-detail/application-detail.component.html
+++ b/src/app/application-management/application-detail/application-detail.component.html
@@ -65,4 +65,4 @@
     </div>
 </div>
 
-<opentosca-management-plan-execution-dialog [(visible)]="dialogVisible" [plan]="currentBuildPlan | async"></opentosca-management-plan-execution-dialog>
+<opentosca-management-plan-execution-dialog [(visible)]="dialogVisible" [plan]="currentBuildPlan | async" [inputValidation]="false"></opentosca-management-plan-execution-dialog>

--- a/src/app/application-management/management-plan-execution-dialog/management-plan-execution-dialog.component.ts
+++ b/src/app/application-management/management-plan-execution-dialog/management-plan-execution-dialog.component.ts
@@ -49,6 +49,9 @@ export class ManagementPlanExecutionDialogComponent {
         }
     }
 
+    @Input()
+    inputValidation: boolean = true;
+
     runnable: boolean;
 
     get hiddenElements(): Array<String> {
@@ -71,6 +74,11 @@ export class ManagementPlanExecutionDialogComponent {
     }
 
     checkInputs(): void {
+        if (!this.inputValidation) {
+            this.runnable = true;
+            return;
+        }
+
         for (const parameter of this.plan.input_parameters) {
             if (parameter.required !== 'YES' || this.hiddenElements.indexOf(parameter.name) !== -1) {
                 continue;


### PR DESCRIPTION
#### Short Description
It's now possible to deactivate the input validation in the management-plan-execution-dialog