### PR TITLE
Update plan-instance.model.ts for monitoring/logging transformation plans

### DIFF
--- a/src/app/core/model/plan-instance.model.ts
+++ b/src/app/core/model/plan-instance.model.ts
@@ -21,7 +21,7 @@ export class PlanInstance extends ResourceSupport {
     service_template_instance_id: string;
     correlation_id: string;
     state: PlanInstanceState;
-    type: 'BUILD' | 'MANAGEMENT' | 'TERMINATION' | 'OTHER';
+    type: 'BUILD' | 'MANAGEMENT' | 'TERMINATION' | 'TRANSFORMATION' | 'OTHER';
     outputs: Array<PlanParameter>;
     logs: Array<PlanLogEntry>;
 }

--- a/src/app/core/model/service-template-instance-state.model.ts
+++ b/src/app/core/model/service-template-instance-state.model.ts
@@ -18,5 +18,6 @@ export enum ServiceTemplateInstanceState {
     CREATED = 'CREATED',
     DELETING = 'DELETING',
     DELETED = 'DELETED',
-    ERROR = 'ERROR'
+    ERROR = 'ERROR',
+    MIGRATED = 'MIGRATED'
 }


### PR DESCRIPTION
Adds transformation plan type (plans that change a service template instance to another service template instance) to enable the monitoring/logging of executing these plans

#### Short Description
The runtime will support the generation of a new plan type that can transform a service template to another, e.g., migrating a service template instance to a new. 

#### Proposed Changes

  * Add ne Plan Type Transformation

