### PR TITLE
Show start and end time for log entries

### DIFF
--- a/src/app/application-management/management-plan-instance-list/management-plan-instance-list.component.html
+++ b/src/app/application-management/management-plan-instance-list/management-plan-instance-list.component.html
@@ -69,8 +69,8 @@
                             <ng-template pTemplate="body" let-rowData let-columns="columns">
                                 <tr>
                                     <td style="word-break: break-all" *ngFor="let col of columns">
-                                        <span *ngIf="col.field === 'timestamp'">{{rowData[col.field] | date:'yyyy-MM-dd HH:mm:ss'}}</span>
-                                        <span *ngIf="col.field !== 'timestamp'">{{rowData[col.field]}}</span>
+                                        <span *ngIf="col.field === 'start_timestamp' || col.field === 'end_timestamp'">{{rowData[col.field] | date:'yyyy-MM-dd HH:mm:ss'}}</span>
+                                        <span *ngIf="col.field !== 'start_timestamp' && col.field !== 'end_timestamp'">{{rowData[col.field]}}</span>
                                     </td>
                                 </tr>
                             </ng-template>

--- a/src/app/application-management/management-plan-instance-list/management-plan-instance-list.component.ts
+++ b/src/app/application-management/management-plan-instance-list/management-plan-instance-list.component.ts
@@ -17,7 +17,8 @@ export class ManagementPlanInstanceListComponent implements OnInit {
     ];
 
     logColumns = [
-        {field: 'timestamp', header: 'Timestamp'},
+        {field: 'start_timestamp', header: 'Start Timestamp'},
+        {field: 'end_timestamp', header: 'End Timestamp'},
         {field: 'status', header: 'Type'},
         {field: 'message', header: 'Message'}
     ];

--- a/src/app/core/model/plan-log-entry.model.ts
+++ b/src/app/core/model/plan-log-entry.model.ts
@@ -13,6 +13,7 @@
  */
 
 export class PlanLogEntry {
-    timestamp: string;
+    start_timestamp: string;
+    end_timestamp: string;
     message: string;
 }


### PR DESCRIPTION
#### Short Description
Display start and end timestamps for plan log entries delivered by the container.

This is related to the following container PR: [#97](https://github.com/OpenTOSCA/container/pull/97)

