### PR TITLE
preserve white spaces in application description

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,6 +29,7 @@ Copyright (c) 2019 Tobias Mathony
 Copyright (c) 2021 Fabian Bühler
 Copyright (c) 2021 Philipp Wundrack
 Copyright (c) 2021 Marvin Bechtold
+Copyright (c) 2022 Miles Stötzner
 
 == Third-party Content
 

--- a/src/app/application-management/application-detail/application-detail.component.html
+++ b/src/app/application-management/application-detail/application-detail.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018 University of Stuttgart.
+  ~ Copyright (c) 2018-2022 University of Stuttgart.
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -23,7 +23,7 @@
                 </div>
                 <div class="p-col">
                     <h3>{{ csar.display_name }}</h3>
-                    <p>{{ csar.description }}</p>
+                    <p class="white-space-pre-line">{{ csar.description }}</p>
                 </div>
             </div>
             <div class="p-grid">

--- a/src/app/application-management/application-overview/application-overview.component.html
+++ b/src/app/application-management/application-overview/application-overview.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018 University of Stuttgart.
+  ~ Copyright (c) 2018-2022 University of Stuttgart.
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -37,7 +37,7 @@
             <div class="ui-card-title truncate">
                 {{ app.display_name }}
             </div>
-            <p-scrollPanel [style]="{width: '100%', height: '80px'}">
+            <p-scrollPanel [style]="{width: '100%', height: '80px'}" class="white-space-pre-line">
                 {{ app.description }}
             </p-scrollPanel>
             <p-footer>

--- a/src/app/repository/repository.component.html
+++ b/src/app/repository/repository.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2018 University of Stuttgart.
+  ~ Copyright (c) 2018-2022 University of Stuttgart.
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -45,7 +45,10 @@
                 {{ app.displayName }}
             </div>
             <p-scrollPanel [style]="{width: '100%', height: '80px'}">
-                <i>{{ app.id }}</i> - {{ app.description }}
+                <i>{{ app.id }}</i>
+                <br/>
+                <br/>
+                <p class="white-space-pre-line">{{ app.description }}</p>
             </p-scrollPanel>
             <p-footer>
                 <button pButton type="button" (click)="openUrl(app.repositoryURL)"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018 University of Stuttgart.
+ * Copyright (c) 2018-2022 University of Stuttgart.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -42,4 +42,8 @@ body {
 
 .ui-growl-message {
   word-break: break-all;
+}
+
+.white-space-pre-line {
+    white-space: break-spaces;
 }


### PR DESCRIPTION
preserve white spaces in application descriptions.
existing descriptions should be adjusted.

- in repository list
- in application list
- in application detail

![image](https://user-images.githubusercontent.com/29414738/156936106-fb4b4397-790b-45d1-8e88-115aa5e8217a.png)
